### PR TITLE
Basic認証の導入（Capistrano未対応）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,17 @@ class ApplicationController < ActionController::Base
   # headers 'X-Frame-Options', 'ALLOWALL'
   # present result
   # response.headers['X-Frame-Options'] = 'ALLOWALL'
-#   response.headers['X-Frame-Options'] = 'ALLOW-FROM http://example.com'
+  # response.headers['X-Frame-Options'] = 'ALLOW-FROM http://example.com'
+  before_action :basic_auth, if: :production?
+
+  private
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end


### PR DESCRIPTION
# What
Basic認証を導入する。

# Why
テスト中の本番環境へのアクセスを制限するため。