### PR TITLE
区分削除機能の修正

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,7 +1,7 @@
 class Section < ApplicationRecord
   belongs_to :user
-  has_many :documents
-  has_many :user_sections
+  has_many :documents, dependent: :destroy
+  has_many :user_sections, dependent: :destroy
   has_many :participate_users, through: :user_sections, source: :user
 
   enum disclosure: [:'参加者のみ公開', :'全体に公開']

--- a/app/views/documents/show.html.haml
+++ b/app/views/documents/show.html.haml
@@ -39,5 +39,5 @@
         .detail-comment__button
           = button_tag type: 'submit', class: 'detail-comment__submit' do
             = icon 'fa', 'comment'
-            コメントする      
+            コメントする
 


### PR DESCRIPTION
# What
区分削除の際、ドキュメントを保有していると外部キー参照のエラーが出る。
dependent: :destroy を付して、関係ドキュメントも削除するようにした。

# Why
エラー回避のため。
もっと良い方法があるかもしれない。